### PR TITLE
List only closed issues

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -12,7 +12,7 @@ app.controller('gitCtrl', function($scope, $http, $location, marked) {
             $scope.userNotFound = false;
             $scope.loaded = false;
             $scope.nouser = false;
-            $http.get("https://api.github.com/repos/" + $scope.username + "/ama/issues?state=all&page="+ $scope.main.page + "&per_page=100")
+            $http.get("https://api.github.com/repos/" + $scope.username + "/ama/issues?state=closed&page="+ $scope.main.page + "&per_page=100")
                  .success(function (data) 
                  {
                   $scope.user = data;


### PR DESCRIPTION
It makes sense to limit the list to only answered (=closed) questions. This patch changes the `state` param for GitHub API call to achieve this.

Readme says this is a fixed problem but apparently it's not (or are you marking TODO list in reverse?).
