### PR TITLE
Adding dates to question and responses.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -87,11 +87,11 @@ a:hover {
     display: block;
     width: 800px;
     /* height: 800px; */
-    
+
     max-height: auto;
     margin: 0 auto;
     /* background: #f8f8f8; */
-    
+
     padding: 130px 25px;
 }
 #gitapidata {
@@ -181,12 +181,22 @@ a:hover {
     margin: 30px;
 }
 .q {
-    margin: 20px 20px 20px 0px;
+    position: relative;
+    margin: 65px 20px 20px 0px;
     text-align: left;
     border: 1.2px solid #616161;
     display: block;
     text-decoration: none;
     padding: 10px;
+}
+.created_at {
+    position: absolute;
+    top: -31px;
+    left: 10px;
+    padding: 8px 14px;
+    color: #fff;
+    font-size: 15px;
+    background: #646464;
 }
 a.active {
     color: red !important;
@@ -197,6 +207,9 @@ a.active {
 .userlinks {
     margin: 0 !important;
     color: rgba(0, 0, 0, .4)
+}
+.commented_on {
+  font-size: 14px;
 }
 .mdcomments a {
     font-size: 23px;

--- a/index.html
+++ b/index.html
@@ -22,21 +22,23 @@
         <div ng-show="loaded" ng-cloak>
             <div ng-repeat="row in user" class="com">
                 <div class="q">
+                    <span class="created_at">{{row.created_at | date:'yyyy-MM-dd'}}</span>
                     <a href="{{row.html_url}}" id="{{row.comments_url}}" data-toggel="modal"
-                    ng-click="UserComment($event);showComments = !showComments;$event.preventDefault();" ng-class="isActive(row)">{{row.title}}
-                        <span ng-repeat="label in row.labels" style="color:red">{{label.name}}</span> 
+                    ng-click="UserComment($event);showComments = !showComments;$event.preventDefault();" ng-class="isActive(row)">
+                        {{row.title}}
+                        <span ng-repeat="label in row.labels" style="color:red">{{label.name}}</span>
                     </a>
-                    
+
                     <div ng-show="showComments">
                         <div ng-repeat="row1 in user1" class="info" ng-if="row.url == row1.issue_url">
                             <h2>
-                                <a class="userlinks" href="{{row1.user.html_url}}">{{row1.user.login}} </a>
+                                <a class="userlinks" href="{{row1.user.html_url}}">{{row1.user.login}} </a> <span class="commented_on">{{row1.created_at | date:"yyyy-MM-dd 'at' hh:mma"}}</span>
                             </h2>
 
                         <div marked="row1.body" class="mdcomments">
-                            
+
                         </div>
-                        
+
                         <span class="add_comment" ng-show="$last">
                             <a href="{{row.html_url}}" class="cm" ng-show="$last" target="_blank">Add your Comment</a>
                         <span>


### PR DESCRIPTION
It's helpful to know when a lot of the responses were given on these types of AMAs. This adds the `created_at` date to the initial issue/question and to each comment.
